### PR TITLE
Add 'requirements.txt' for pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+sqlalchemy
+sqlalchemy-migrate
+pysqlite
+nltk
+beautifulsoup4
+sed


### PR DESCRIPTION
According to https://pip.pypa.io/en/stable/user_guide/#requirements-files, all Python projects should include a `requirements.txt` file so that dependencies can be installed via the command `pip install -r requirements.txt`.

This pull request adds the necessary packages to `requirements.txt` from `README.md` to enable this command.